### PR TITLE
Prevent timeouts

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ provider:
   runtime: rust
   region: eu-west-1
   memorySize: 128
-  timeout: 10
+  timeout: 30
   reservedConcurrency: 3
   stage: staging
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn telegram_webhook_handler(
 
 fn handle_inline_query(update: &TelegramUpdate) {
     let q = update.inline_query.as_ref().unwrap();
+    println!("Inline Query: {}", q.query);
 
     if q.query.len() == 0 {
         return;
@@ -57,6 +58,7 @@ fn handle_inline_query(update: &TelegramUpdate) {
 
 fn handle_message(update: &TelegramUpdate) {
     let msg = update.message.as_ref().unwrap();
+    println!("Message: {:?}", msg.text);
 
     // Handle any [[ ]] references before checking for commands etc.
     handle_plaintext(update);

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,7 @@ fn handle_plaintext(update: &TelegramUpdate) {
 
     let results: Vec<String> = re
         .captures_iter(&msg_text)
+        .take(10)
         .filter_map(|cap| single_card_image_with_fallback(cap.get(1).unwrap().as_str()))
         .collect();
 


### PR DESCRIPTION
Quick-fix for #4 .

- Limit handled cards in always-on mode to 10, as a Telegram MediaGallery is also limited to 10 items.
- Increase the Lambda timeout to 30s, as a long wait time is preferable over a timeout.
- Re-added some logging (but without any privacy-sensitive context), because debugging/performance tracing is impossible otherwise.