### PR TITLE
Feature: Support Double Faced Cards (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,7 @@ dependencies = [
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1161,6 +1162,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
@@ -1689,6 +1695,7 @@ dependencies = [
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
+"checksum strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = "^0.9.18"
 regex = "1"
+strsim = "^0.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,8 @@ fn handle_plaintext(update: &TelegramUpdate) {
                 cap.get(1).unwrap().as_str(),
                 cap.get(2).map(|c| c.as_str()),
             )
+            .ok()
+            .flatten()
         })
         .collect();
 

--- a/src/scryfall/api.rs
+++ b/src/scryfall/api.rs
@@ -1,7 +1,7 @@
 use reqwest;
-use reqwest::{RedirectPolicy, StatusCode, Url};
+use reqwest::{StatusCode, Url};
 
-use crate::scryfall::models::SearchResult;
+use crate::scryfall::models::{Card, SearchResult};
 
 const BASE_URL: &str = "https://api.scryfall.com/";
 
@@ -31,40 +31,35 @@ pub fn cards_search(query: &str, order: &str, page: i32) -> reqwest::Result<Sear
     }
 }
 
-pub fn single_card_image(query: &str, set: Option<&str>) -> Option<String> {
+pub fn single_card_image(query: &str, set: Option<&str>) -> reqwest::Result<Option<String>> {
     let base = Url::parse(BASE_URL).unwrap();
     let mut endpoint = base.join("cards/named").unwrap();
 
-    endpoint
-        .query_pairs_mut()
-        .append_pair("fuzzy", query)
-        .append_pair("format", "image");
+    endpoint.query_pairs_mut().append_pair("fuzzy", query);
 
     if set.is_some() {
         endpoint.query_pairs_mut().append_pair("set", set.unwrap());
     }
 
-    let client = reqwest::Client::builder()
-        .redirect(RedirectPolicy::none())
-        .build()
-        .unwrap();
+    let response = reqwest::get(endpoint)?.error_for_status();
 
-    let response = client.get(endpoint).send().unwrap();
-
-    match response.status() {
-        StatusCode::FOUND => response
-            .headers()
-            .get("Location")
-            .and_then(|val| Some(String::from(val.to_str().unwrap()))),
-        _ => None,
+    match response {
+        Ok(mut resp) => {
+            let res: Card = resp.json().unwrap();
+            Ok(image_for_card(&res, query, "normal"))
+        }
+        Err(e) => Err(e),
     }
 }
 
-pub fn single_card_image_with_fallback(query: &str, set: Option<&str>) -> Option<String> {
-    let named_result = single_card_image(query, set);
+pub fn single_card_image_with_fallback(
+    query: &str,
+    set: Option<&str>,
+) -> reqwest::Result<Option<String>> {
+    let named_result = single_card_image(query, set).ok().flatten();
 
     if named_result.is_some() {
-        return named_result;
+        return Ok(named_result);
     }
 
     let query_with_set = match set {
@@ -72,28 +67,32 @@ pub fn single_card_image_with_fallback(query: &str, set: Option<&str>) -> Option
         None => String::from(query),
     };
 
-    match cards_search(&query_with_set, "name", 1) {
-        Ok(resp) => {
-            for card in resp.data? {
-                let images = match card.image_uris {
-                    Some(_) => card.image_uris,
-                    None => card.card_faces?[0].image_uris.clone(),
-                };
-
-                match images {
-                    Some(img) => {
-                        if img.contains_key("large") {
-                            return Some(img["large"].clone());
-                        }
-                        continue;
-                    }
-                    _ => continue,
-                }
-            }
-            None
-        }
-        _ => None,
+    let search_res = cards_search(&query_with_set, "name", 1)?;
+    match search_res.data {
+        Some(cards) => Ok(cards
+            .first()
+            .and_then(|c| image_for_card(c, query, "normal"))),
+        None => Ok(None),
     }
+}
+
+fn image_for_card(card: &Card, name_of_interest: &str, preferred_format: &str) -> Option<String> {
+    let images = match &card.card_faces {
+        None => &card.image_uris,
+        Some(faces) => {
+            // If the card has multiple faces, return the face that matches closest to what the user
+            // expects:
+            let wanted_face = &faces[0];
+
+            &wanted_face.image_uris
+        }
+    }
+    .as_ref()?;
+
+    images
+        .get(preferred_format)
+        .cloned()
+        .or_else(|| images.values().next().cloned())
 }
 
 #[cfg(test)]
@@ -109,35 +108,49 @@ mod tests {
 
     #[test]
     fn test_get_card_by_name() {
-        let result = single_card_image("Nyx-fleece ram", None);
+        let result = single_card_image("Nyx-fleece ram", None).unwrap();
 
         assert_eq!(result.is_some(), true);
     }
 
     #[test]
     fn test_get_card_by_name_and_set() {
-        let result = single_card_image("Nyx-fleece ram", Some("JOU"));
+        let result = single_card_image("Nyx-fleece ram", Some("JOU")).unwrap();
 
         assert_eq!(result.is_some(), true);
     }
 
     #[test]
     fn test_get_card_by_name_fuzzy() {
-        let result = single_card_image("bolas dragon god", None);
+        let result = single_card_image("bolas dragon god", None).unwrap();
+
+        assert_eq!(result.is_some(), true);
+    }
+
+    #[test]
+    fn test_get_double_faced_card_by_name() {
+        let result = single_card_image("Insectile Aberration", None).unwrap();
 
         assert_eq!(result.is_some(), true);
     }
 
     #[test]
     fn test_get_card_by_name_with_fallback_fuzzy() {
-        let result = single_card_image_with_fallback("gatstaf", None);
+        let result = single_card_image_with_fallback("nyx", None).unwrap();
+
+        assert_eq!(result.is_some(), true);
+    }
+
+    #[test]
+    fn test_get_double_faced_card_by_name_with_fallback_fuzzy() {
+        let result = single_card_image_with_fallback("gatstaf", None).unwrap();
 
         assert_eq!(result.is_some(), true);
     }
 
     #[test]
     fn test_get_card_by_name_with_fallback_fuzzy_with_set() {
-        let result = single_card_image_with_fallback("gatstaf", Some("SOI"));
+        let result = single_card_image_with_fallback("gatstaf", Some("SOI")).unwrap();
 
         assert_eq!(result.is_some(), true);
     }

--- a/src/scryfall/models.rs
+++ b/src/scryfall/models.rs
@@ -24,5 +24,6 @@ pub struct Card {
 /// Unused fields are omitted
 #[derive(Deserialize)]
 pub struct Face {
+    pub name: String,
     pub image_uris: Option<HashMap<String, String>>,
 }


### PR DESCRIPTION
Implements #9 

If multiple card faces are present in the Scryfall response, we select the one whose name is most similar to the user provided query.