### PR TITLE
Feature: Pricing information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2021-09-12
+
+### Added
+
+- Fetch card price information by prepending a '$' or '€' sign to your query.
+
 ## [2.0.0] - 2021-09-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Scryfall telegram is both an inline and always-on [Telegram](https://telegram.or
 All Scryfall syntax that can be understood by the API can be used in inline mode. A full reference
 can be found here: [Scryfall Syntax Reference](https://scryfall.com/docs/reference).
 
-For always-on mode, add [ScryfallBot](https://t.me/ScryfallBot) to your chat and mark cards to be looked up with `[[ card you want to find ]]`.
+For always-on mode, add [ScryfallBot](https://t.me/ScryfallBot) to your chat and mark cards to be looked up with `[[ card you want to find ]]`. The bot will search up to 10 cards per message.
 You can find a specific printing or limit the search to a specific set by adding the 3 letter set code like this: `[[ my card | SET ]]`
+Starting the query with a '$' or '€' sign will make the bot include pricing information in the image caption: `[[ $ nyx-fleece ram ]]`
 
 NOTE: Currently, the bot needs to be an admin in your chat in order to see messages without being explicitly mentioned...
 
@@ -19,6 +20,7 @@ Some inline examples:
 Some always-on examples:
 - Does anyone have an extra [[ nyx fleece ram ]] or [[ bolas dragon god ]] ?
 - Which is best: [[Bottle Gnomes|TMP]] or [[Bottle Gnomes]] ?
+- How expensive is this invocation? [[ $ Damnation | MP2 ]]
 
 ## Running it yourself
 

--- a/scryfall_telegram/textmessage.py
+++ b/scryfall_telegram/textmessage.py
@@ -140,10 +140,14 @@ Welcome to ScryfallBot!
 
 *Usage*
 ScryfallBot works in both _inline_ mode and in active mode.
+
 Inline mode means you just tag @ScryfallBot and start typing while the results show up above your keyboard.
 Tapping a result will send it in your chat. All Scryfall syntax is supported, for a full overview, see [the Scryfall syntax docs](https://scryfall.com/docs/syntax)
+
 Active mode means you can add ScryfallBot to a chat and look up cards by typing [[ your card here ]] in chat.
+The bot will search up to 10 cards per message.
 You can find specific printings or limit the search to a set by adding the set code like this: [[ my card lookup | SET ]].
+If you start the query with a '$' or '€' sign, the bot will include price information about the card: [[ $ nyx-fleece ]].
 
 NOTE: Currently, the bot needs to be an admin in your chat in order to see messages without being explicitly mentioned...
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import os
+
+import pytest
+
+from scryfall_telegram.telegram.client import cached_telegram_client
+
+
+@pytest.fixture()
+def bot_token(monkeypatch):
+    try:
+        stag_token = os.environ["TELEGRAM_BOT_TOKEN_STAG"]
+    except KeyError:
+        pytest.skip("TELEGRAM_BOT_TOKEN_STAG missing from env.")
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", stag_token)
+
+
+@pytest.fixture(scope="session")
+def chat_id():
+    try:
+        id = os.environ["TEST_CHAT_ID"]
+    except KeyError:
+        pytest.skip("TEST_CHAT_ID missing from env.")
+
+    return int(id)
+
+
+@pytest.fixture()
+def telegram(bot_token):
+    return cached_telegram_client()

--- a/tests/integration/test_telegram.py
+++ b/tests/integration/test_telegram.py
@@ -1,0 +1,39 @@
+from scryfall_telegram.telegram.models import (
+    InputMediaPhoto,
+    SendMediaGroup,
+    SendMessage,
+    SendPhoto,
+)
+
+TEST_PHOTO = "https://c1.scryfall.com/file/scryfall-cards/png/front/a/d/ad98e518-4ec9-403e-a978-217244262c8f.png?1562439724"
+
+
+class TestTelegramClient:
+    def test_send_message(self, telegram, chat_id):
+        resp = telegram.send_message(
+            SendMessage(
+                chat_id=chat_id, text="scryfall-telegram integration test message."
+            )
+        )
+        resp.raise_for_status()
+
+    def test_send_photo(self, telegram, chat_id):
+        resp = telegram.send_photo(
+            SendPhoto(
+                chat_id=chat_id,
+                photo=TEST_PHOTO,
+                caption="scryfall-telegram integration test photo.",
+            )
+        )
+        resp.raise_for_status()
+
+    def test_send_media_group(self, telegram, chat_id):
+        resp = telegram.send_media_group(
+            SendMediaGroup(
+                chat_id=chat_id,
+                media=[
+                    InputMediaPhoto(type="photo", media=TEST_PHOTO) for _ in range(3)
+                ],
+            )
+        )
+        resp.raise_for_status()

--- a/tests/integration/test_textmessage.py
+++ b/tests/integration/test_textmessage.py
@@ -1,0 +1,44 @@
+from typing import List
+
+from scryfall_telegram.telegram.models import Chat, Message, MessageEntity, User
+from scryfall_telegram.textmessage import handle_message
+
+
+def fake_message(chat_id: int, text: str, entities: List[MessageEntity]) -> Message:
+    return {
+        "date": 123,
+        "chat": Chat(id=chat_id, username="Test chat", type="private"),
+        "message_id": 1,
+        "from": User(id=1, first_name="Oliver"),
+        "text": text,
+        "entities": entities,
+    }
+
+
+def test_handle_start_command(telegram, chat_id):
+    msg = fake_message(
+        chat_id, "/start", [MessageEntity(type="bot_command", offset=0, length=6)]
+    )
+    handle_message(msg)
+
+
+def test_simple_basic_card(telegram, chat_id):
+    msg = fake_message(chat_id, "Hello [[ Nyx-Fleece Ram ]]", [])
+    handle_message(msg)
+
+
+def test_simple_multiple_cards(telegram, chat_id):
+    msg = fake_message(chat_id, "Hello [[delver secrets]] [[insectile aberration]]", [])
+    handle_message(msg)
+
+
+def test_simple_basic_card_prices(telegram, chat_id):
+    msg = fake_message(chat_id, "Hello [[ $ Nyx-Fleece Ram ]]", [])
+    handle_message(msg)
+
+
+def test_simple_multiple_cards_prices(telegram, chat_id):
+    msg = fake_message(
+        chat_id, "Hello [[ $ delver secrets]] [[ € insectile aberration]]", []
+    )
+    handle_message(msg)

--- a/tests/unit/test_inline.py
+++ b/tests/unit/test_inline.py
@@ -1,0 +1,18 @@
+from scryfall_telegram.inline import scryfall_card_to_inline_query_article
+from scryfall_telegram.scryfall.models import Card
+
+
+def test_scryfall_card_to_inline_query_article():
+    card = Card(
+        id="abc123",
+        name="Nyx-Fleece Ram",
+        type_line="Enchantment Creature - Sheep",
+        oracle_text="You win the game.",
+        scryfall_uri="https://scryfall.com/card/a25/26/nyx-fleece-ram",
+        image_uris={
+            "normal": "https://c1.scryfall.com/file/scryfall-cards/png/front/a/d/ad98e518-4ec9-403e-a978-217244262c8f.png?1562439724"
+        },
+        prices={"eur": "666.99"},
+    )
+
+    assert scryfall_card_to_inline_query_article(card)

--- a/tests/unit/test_scryfall.py
+++ b/tests/unit/test_scryfall.py
@@ -1,0 +1,31 @@
+from scryfall_telegram.scryfall.service import image_for_card
+
+GOOD_URL = "https://scryfall.com"
+BAD_URL = "https://sc.am"
+
+
+def test_image_for_card_root():
+    card = dict(id="123", name="test", image_uris=dict(small=BAD_URL, normal=GOOD_URL))
+
+    assert image_for_card(card, "test", "normal") == GOOD_URL
+
+
+def test_image_for_card_root_format_fallback():
+    card = dict(id="123", name="test", image_uris=dict(small=GOOD_URL))
+
+    assert image_for_card(card, "test", "normal") == GOOD_URL
+
+
+def test_image_for_card_face():
+    card = dict(
+        id="123",
+        name="test",
+        card_faces=[
+            dict(name="correct", image_uris=dict(normal=GOOD_URL)),
+            dict(name="wrong", image_uris=dict(normal=BAD_URL)),
+        ],
+    )
+    assert image_for_card(card, "correct", "normal") == GOOD_URL
+    assert image_for_card(card, "wrong", "normal") == BAD_URL
+    # Small typo's should be forgiven:
+    assert image_for_card(card, "corretc", "normal") == GOOD_URL

--- a/tests/unit/test_textmessage.py
+++ b/tests/unit/test_textmessage.py
@@ -1,0 +1,8 @@
+from scryfall_telegram.scryfall.models import Prices
+from scryfall_telegram.textmessage import _textify_prices
+
+
+def test_textify_prices():
+    prices = Prices(usd="1.2", usd_foil="5.0", eur="1.0", eur_foil="2.0", tix="0.3")
+    res = _textify_prices(prices)
+    assert isinstance(res, str)

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ extras =
     testing
 passenv =
     PYTHONBREAKPOINT
+    TEST_CHAT_ID
+    TELEGRAM_BOT_TOKEN_STAG
 commands =
     pytest {posargs:tests/unit/ tests/integration/}
 


### PR DESCRIPTION
Implements #14 

Adding a '$' or '€' character in the beginning of your query will make the bot add pricing information to the image caption.
This works for both single cards and in card galleries (>1 results). This also takes into account the set information if given (e.g. masterpiece damnation: `[[ $ Damnation | MP2 ]]`).
