### PR TITLE
fix: Add custom User-Agent header to Scryfall client

### DIFF
--- a/scryfall_telegram/scryfall/client.py
+++ b/scryfall_telegram/scryfall/client.py
@@ -16,6 +16,9 @@ def cached_scryfall_client():
 class ScryfallClient:
     def __init__(self):
         self.session = requests.Session()
+        self.session.headers.update({
+            "User-Agent": "ScryfallTelegramBot/2.6.0 (https://github.com/OliverHofkens/scryfall-telegram)"
+        })
 
     def _get(self, url: str, **params):
         resp = self.session.get(_BASE_URL + url, params=params)


### PR DESCRIPTION
### Description
Scryfall's API recently started rejecting HTTP requests that use default library `User-Agent` strings (such as `python-requests/x.y.z`), returning a `400 Bad Request` with `subcode: generic_user_agent`. This was causing the bot to fail completely when querying the API.

This PR adds a custom `User-Agent` header (`ScryfallTelegramBot/2.6.0 (+https://github.com/OliverHofkens/scryfall-telegram)`) to the `requests.Session` in `ScryfallClient`.

### Testing
- Ran local unit and integration tests under `tests/` which now pass successfully.
- Manually verified that Scryfall API no longer returns 400 errors when using the custom User-Agent.